### PR TITLE
feat: Implement basic UIs for placeholder tools

### DIFF
--- a/src/components/cognicanvas/tools/code-editor.tsx
+++ b/src/components/cognicanvas/tools/code-editor.tsx
@@ -3,11 +3,20 @@
 
 import type { ToolProps } from '@/components/cognicanvas/types';
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { AgentStream } from '@/components/cognicanvas/agent-stream';
 import { SmartSuggestions } from '@/components/cognicanvas/smart-suggestions';
-import { Code } from 'lucide-react';
+import { Code, Play, Save, FileCog } from 'lucide-react';
 
 export const CodeEditor: React.FC<ToolProps> = ({ tool, onContentChange }) => {
+  const sampleCode = `
+function greet(name: string) {
+  console.log(\`Hello, \${name}!\`);
+}
+
+greet('World');
+  `.trim();
+
   return (
     <Card className="h-full flex flex-col shadow-xl rounded-lg overflow-hidden border-border bg-card">
       <CardHeader className="bg-card border-b p-4">
@@ -18,11 +27,26 @@ export const CodeEditor: React.FC<ToolProps> = ({ tool, onContentChange }) => {
       </CardHeader>
       <CardContent className="p-0 flex-grow flex flex-row overflow-hidden">
         {/* Main Tool content area */}
-        <div className="flex-grow flex flex-col items-center justify-center p-4 bg-card text-muted-foreground">
-          <Code className="w-16 h-16 mb-4 text-primary/30" />
-          <h2 className="text-xl font-semibold mb-2 text-foreground">{tool.name} UI</h2>
-          <p className="text-center">The main interface for {tool.name} will be implemented here.</p>
-          <p className="text-xs mt-2">(e.g., syntax highlighting, file tree, terminal)</p>
+        <div className="flex-grow flex flex-col p-4 bg-background">
+          <div className="flex items-center justify-end mb-2 space-x-2">
+            <Button variant="outline" size="sm">
+              <Play className="mr-2 h-4 w-4" />
+              Run
+            </Button>
+            <Button variant="outline" size="sm">
+              <Save className="mr-2 h-4 w-4" />
+              Save
+            </Button>
+            <Button variant="outline" size="sm">
+              <FileCog className="mr-2 h-4 w-4" />
+              Format
+            </Button>
+          </div>
+          <div className="flex-grow rounded-md border border-input bg-card p-4 overflow-auto">
+            <pre className="text-sm text-card-foreground">
+              <code>{sampleCode}</code>
+            </pre>
+          </div>
         </div>
         {/* Agent Stream + Smart Suggestions part */}
         <div className="w-[340px] md:w-[380px] lg:w-[420px] border-l border-border flex flex-col bg-sidebar text-sidebar-foreground shrink-0">

--- a/src/components/cognicanvas/tools/comms-hub.tsx
+++ b/src/components/cognicanvas/tools/comms-hub.tsx
@@ -4,9 +4,13 @@
 import type { ToolProps } from '@/components/cognicanvas/types';
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { AgentStream } from '@/components/cognicanvas/agent-stream';
 import { SmartSuggestions } from '@/components/cognicanvas/smart-suggestions';
-import { Mail, Users, Video, ArrowLeft, MessageSquare } from 'lucide-react';
+import { 
+  Mail, Users, Video, ArrowLeft, MessageSquare, Send, Inbox, Archive, 
+  Rss, AtSign, PlusSquare, MicOff, VideoOff, PhoneOff, ScreenShare, UserCircle
+} from 'lucide-react';
 import React, { useState } from 'react';
 
 interface CommsFeature {
@@ -80,25 +84,165 @@ export const CommsHub: React.FC<ToolProps> = ({ tool, onContentChange }) => {
 
   const renderSelectedFeature = () => {
     if (!selectedFeature) return null;
-    return (
-      <div className="flex flex-col items-center justify-center h-full p-4 text-center">
+
+    const commonLayoutClasses = "w-full h-full p-4 flex flex-col bg-background"; // Added bg-background
+
+    const header = (
+      <>
         <Button
           variant="ghost"
           onClick={handleBackToSelection}
-          className="absolute top-4 left-4 text-sm"
+          className="absolute top-4 left-4 text-sm z-10"
         >
           <ArrowLeft className="mr-2 h-4 w-4" />
-          Back to Comms Hub
+          Back
         </Button>
-        <selectedFeature.icon className="w-20 h-20 mb-6 text-primary" />
-        <h2 className="text-3xl font-semibold mb-3 text-foreground">{selectedFeature.name}</h2>
+        <div className="flex flex-col items-center justify-center pt-8 pb-4 text-center relative">
+          <selectedFeature.icon className="w-12 h-12 mb-3 text-primary" />
+          <h2 className="text-2xl font-semibold text-foreground">{selectedFeature.name}</h2>
+        </div>
+      </>
+    );
+
+    if (selectedFeature.id === 'email') {
+      return (
+        <div className={commonLayoutClasses}>
+          {header}
+          <div className="flex-grow flex rounded-md border bg-card text-card-foreground shadow">
+            <div className="w-1/4 border-r p-4 space-y-2">
+              <Button variant="default" className="w-full justify-start">
+                <PlusSquare className="mr-2 h-4 w-4" /> Compose
+              </Button>
+              <Button variant="ghost" className="w-full justify-start">
+                <Inbox className="mr-2 h-4 w-4" /> Inbox
+              </Button>
+              <Button variant="ghost" className="w-full justify-start">
+                <Send className="mr-2 h-4 w-4" /> Sent
+              </Button>
+              <Button variant="ghost" className="w-full justify-start">
+                <Archive className="mr-2 h-4 w-4" /> Archive
+              </Button>
+            </div>
+            <div className="w-3/4 p-4">
+              <h3 className="text-lg font-semibold mb-2">Inbox</h3>
+              <div className="space-y-3">
+                {[
+                  { sender: 'Alice Wonderland', subject: 'Project Update', snippet: 'Just wanted to share the latest progress...' },
+                  { sender: 'Bob The Builder', subject: 'Meeting Reminder', snippet: 'Friendly reminder about our meeting tomorrow...' },
+                  { sender: 'Carol Danvers', subject: 'Weekend Plans?', snippet: 'Hey, any plans for the upcoming weekend?' },
+                ].map((email, i) => (
+                  <div key={i} className="p-3 border rounded-md hover:bg-accent cursor-pointer">
+                    <p className="font-semibold text-sm">{email.sender}</p>
+                    <p className="text-xs text-muted-foreground">{email.subject}</p>
+                    <p className="text-xs truncate">{email.snippet}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    if (selectedFeature.id === 'social') {
+      return (
+        <div className={commonLayoutClasses}>
+          {header}
+          <div className="flex-grow flex rounded-md border bg-card text-card-foreground shadow">
+            <div className="w-1/4 border-r p-4 space-y-2">
+              <Button variant="default" className="w-full justify-start">
+                <PlusSquare className="mr-2 h-4 w-4" /> New Post
+              </Button>
+              <Button variant="ghost" className="w-full justify-start">
+                <Rss className="mr-2 h-4 w-4" /> Feed
+              </Button>
+              <Button variant="ghost" className="w-full justify-start">
+                <AtSign className="mr-2 h-4 w-4" /> Mentions
+              </Button>
+            </div>
+            <div className="w-3/4 p-4 space-y-4 overflow-y-auto">
+              <h3 className="text-lg font-semibold mb-2">Feed</h3>
+              {[
+                { user: 'TechGuru', avatar: '/avatars/01.png', content: 'Just unboxed the new AI gadget! #AI #Tech #Innovation' },
+                { user: 'FoodieFan', avatar: '/avatars/02.png', content: 'Trying out a new recipe tonight. Wish me luck! 🍲 #Food #Cooking' },
+                { user: 'TravelExplorer', avatar: '/avatars/03.png', content: 'Exploring the beautiful mountains of Switzerland! 🏔️ #Travel #Adventure' },
+              ].map((post, i) => (
+                <Card key={i} className="bg-background">
+                  <CardHeader className="p-3">
+                    <div className="flex items-center space-x-3">
+                      <Avatar className="h-10 w-10">
+                        <AvatarImage src={post.avatar} alt={post.user} />
+                        <AvatarFallback>{post.user.substring(0,2)}</AvatarFallback>
+                      </Avatar>
+                      <div>
+                        <p className="font-semibold text-sm">{post.user}</p>
+                        <p className="text-xs text-muted-foreground">2 hours ago</p>
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="p-3 pt-0">
+                    <p className="text-sm">{post.content}</p>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    if (selectedFeature.id === 'video') {
+      return (
+        <div className={commonLayoutClasses}>
+          {header}
+          <div className="flex-grow flex flex-col rounded-md border bg-card text-card-foreground shadow overflow-hidden">
+            <div className="flex-grow bg-muted/40 flex items-center justify-center relative p-2">
+              <div className="w-full h-full bg-black rounded flex items-center justify-center text-white">
+                Main Video Feed (Participant A)
+              </div>
+              <div className="absolute bottom-2 right-2 grid grid-cols-2 gap-1">
+                {[1, 2, 3].map(p => (
+                  <div key={p} className="w-24 h-16 bg-slate-700 rounded flex items-center justify-center text-white text-xs p-1">
+                    User {String.fromCharCode(65 + p)}
+                  </div>
+                ))}
+                 <div className="w-24 h-16 bg-slate-800 rounded flex items-center justify-center text-white text-xs p-1">
+                    You
+                  </div>
+              </div>
+            </div>
+            <div className="border-t p-3 bg-card flex justify-center items-center space-x-2">
+              <Button variant="outline" size="icon" className="bg-red-500 hover:bg-red-600 text-white">
+                <PhoneOff className="h-5 w-5" />
+              </Button>
+              <Button variant="outline" size="icon">
+                <MicOff className="h-5 w-5" />
+              </Button>
+              <Button variant="outline" size="icon">
+                <VideoOff className="h-5 w-5" />
+              </Button>
+              <Button variant="outline" size="icon">
+                <ScreenShare className="h-5 w-5" />
+              </Button>
+               <Button variant="outline" size="icon">
+                <Users className="h-5 w-5" />
+              </Button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // Fallback for any other feature or if logic is missing (should not happen with current setup)
+    return (
+      <div className="flex flex-col items-center justify-center h-full p-4 text-center">
+        {header}
         <p className="text-muted-foreground mb-4">
-          The interface for {selectedFeature.name} will be displayed here.
+          The interface for {selectedFeature.name} is under construction.
         </p>
         <div className="w-full max-w-md p-8 border border-dashed rounded-lg bg-background shadow-inner">
           <p className="text-sm text-muted-foreground">
-            This is where the dedicated UI for AI-powered {selectedFeature.name.toLowerCase()} would be.
-            Interact with the AI agent on the right for assistance with {selectedFeature.name.toLowerCase().split(' ')[0]} tasks.
+            AI assistance for {selectedFeature.name.toLowerCase()} is available via the agent panel.
           </p>
         </div>
       </div>

--- a/src/components/cognicanvas/tools/creative-suite.tsx
+++ b/src/components/cognicanvas/tools/creative-suite.tsx
@@ -6,7 +6,12 @@ import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '@/componen
 import { Button } from '@/components/ui/button';
 import { AgentStream } from '@/components/cognicanvas/agent-stream';
 import { SmartSuggestions } from '@/components/cognicanvas/smart-suggestions';
-import { ImageIcon, Music, Film, ArrowLeft, Palette } from 'lucide-react';
+import { 
+  ImageIcon, Music, Film, ArrowLeft, Palette, Wand2, Sparkles,
+  Brush, Pencil, Eraser, Type as TypeIcon, AlignLeft,
+  Play as PlayIcon, Mic, PlusSquare, GripVertical, Waves,
+  FileVideo, Scissors, CaseSensitive, UploadCloud, SlidersHorizontal
+} from 'lucide-react';
 import React, { useState } from 'react';
 
 interface CreativeFeature {
@@ -80,25 +85,131 @@ export const CreativeSuite: React.FC<ToolProps> = ({ tool, onContentChange }) =>
 
   const renderSelectedFeature = () => {
     if (!selectedFeature) return null;
-    return (
-      <div className="flex flex-col items-center justify-center h-full p-4 text-center">
-        <Button 
-          variant="ghost" 
-          onClick={handleBackToSelection} 
-          className="absolute top-4 left-4 text-sm"
+
+    const commonLayoutClasses = "w-full h-full p-4 flex flex-col bg-card text-card-foreground";
+
+    const header = (
+      <>
+        <Button
+          variant="ghost"
+          onClick={handleBackToSelection}
+          className="absolute top-4 left-4 text-sm z-10 text-muted-foreground hover:text-foreground"
         >
           <ArrowLeft className="mr-2 h-4 w-4" />
-          Back to Creative Tools
+          Back
         </Button>
-        <selectedFeature.icon className="w-20 h-20 mb-6 text-primary" />
-        <h2 className="text-3xl font-semibold mb-3 text-foreground">{selectedFeature.name}</h2>
+        <div className="flex flex-col items-center justify-center pt-8 pb-4 text-center relative mb-2">
+          <selectedFeature.icon className="w-12 h-12 mb-3 text-primary" />
+          <h2 className="text-2xl font-semibold">{selectedFeature.name}</h2>
+        </div>
+      </>
+    );
+
+    if (selectedFeature.id === 'image') {
+      return (
+        <div className={commonLayoutClasses}>
+          {header}
+          <div className="flex-grow flex rounded-md border shadow-inner overflow-hidden">
+            <div className="w-16 bg-muted/30 border-r p-2 flex flex-col items-center space-y-3">
+              {[Brush, Pencil, Eraser, TypeIcon, AlignLeft, Wand2].map((Icon, i) => (
+                <Button key={i} variant="ghost" size="icon" className="hover:bg-primary/10">
+                  <Icon className="h-5 w-5 text-muted-foreground group-hover:text-primary" />
+                </Button>
+              ))}
+            </div>
+            <div className="flex-grow flex flex-col">
+              <div className="flex-grow bg-muted/20 flex items-center justify-center p-4">
+                <div className="w-full h-full border-2 border-dashed border-input rounded-lg flex items-center justify-center text-muted-foreground">
+                  Canvas Area
+                </div>
+              </div>
+              <div className="p-2 border-t bg-muted/30 flex justify-end">
+                <Button>
+                  <Sparkles className="mr-2 h-4 w-4" /> Generate Image
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    if (selectedFeature.id === 'music') {
+      return (
+        <div className={commonLayoutClasses}>
+          {header}
+          <div className="flex-grow flex flex-col rounded-md border shadow-inner overflow-hidden">
+            <div className="p-3 border-b bg-muted/30 flex items-center space-x-2">
+              <Button variant="ghost" size="icon"><PlayIcon className="h-5 w-5" /></Button>
+              <Button variant="ghost" size="icon"><Mic className="h-5 w-5" /></Button>
+              <Button variant="ghost" size="icon"><PlusSquare className="h-5 w-5" /></Button>
+              <span className="text-sm text-muted-foreground ml-auto">00:00 / 00:00</span>
+            </div>
+            <div className="flex-grow p-4 space-y-3 overflow-y-auto bg-muted/20">
+              {['Synth Lead', 'Drum Beat', 'Bass Line', 'Ambient Pad'].map((trackName, i) => (
+                <div key={i} className="p-3 border rounded-md bg-card flex items-center shadow-sm">
+                  <GripVertical className="h-5 w-5 text-muted-foreground mr-2 cursor-grab" />
+                  <Waves className="h-5 w-5 text-primary mr-3" />
+                  <span className="text-sm font-medium flex-grow">{trackName}</span>
+                  <Button variant="ghost" size="icon" className="text-muted-foreground hover:text-primary">
+                    <SlidersHorizontal className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+             <div className="p-2 border-t bg-muted/30 flex justify-end">
+                <Button>
+                  <Sparkles className="mr-2 h-4 w-4" /> Generate Music
+                </Button>
+              </div>
+          </div>
+        </div>
+      );
+    }
+
+    if (selectedFeature.id === 'video') {
+      return (
+        <div className={commonLayoutClasses}>
+          {header}
+          <div className="flex-grow grid grid-rows-[2fr_1fr] gap-2 rounded-md border shadow-inner overflow-hidden">
+            <div className="bg-muted/20 flex items-center justify-center p-2">
+              <div className="w-full h-full border-2 border-dashed border-input rounded-lg flex items-center justify-center text-muted-foreground">
+                Video Preview
+              </div>
+            </div>
+            <div className="flex flex-col bg-muted/30 border-t overflow-hidden">
+              <div className="p-2 border-b flex items-center space-x-2">
+                <Button variant="outline" size="sm"><UploadCloud className="mr-2 h-4 w-4" /> Import</Button>
+                <Button variant="outline" size="sm"><Scissors className="mr-2 h-4 w-4" /> Split</Button>
+                <Button variant="outline" size="sm"><CaseSensitive className="mr-2 h-4 w-4" /> Text</Button>
+                 <Button variant="outline" size="sm" className="ml-auto"><Sparkles className="mr-2 h-4 w-4" /> Auto Edit</Button>
+              </div>
+              <div className="flex-grow p-2 space-x-1 bg-muted/10 overflow-x-auto whitespace-nowrap">
+                {['Clip1.mp4', 'Transition', 'Clip2.mp4', 'Title.mov', 'Music.mp3'].map((item, i) => (
+                  <div key={i} className={`inline-block h-full p-2 rounded-md text-xs items-center justify-center flex
+                    ${item.includes('Clip') || item.includes('mov') ? 'bg-primary/20 text-primary-foreground w-24' : ''} 
+                    ${item.includes('Transition') ? 'bg-accent text-accent-foreground w-16' : ''}
+                    ${item.includes('Music') ? 'bg-green-500/20 text-green-700 w-32' : ''} `}>
+                    {item}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // Fallback
+    return (
+      <div className="flex flex-col items-center justify-center h-full p-4 text-center">
+        {header}
         <p className="text-muted-foreground mb-4">
-          The interface for {selectedFeature.name} will be displayed here.
+          The interface for {selectedFeature.name} is under construction.
         </p>
-        <div className="w-full max-w-md p-8 border border-dashed rounded-lg bg-background shadow-inner">
+        <div className="w-full max-w-md p-8 border border-dashed rounded-lg bg-card shadow-inner">
           <p className="text-sm text-muted-foreground">
-            This is where the dedicated UI for AI-powered {selectedFeature.name.toLowerCase()} would be.
-            Interact with the AI agent on the right for assistance.
+            AI assistance for {selectedFeature.name.toLowerCase()} is available via the agent panel.
           </p>
         </div>
       </div>

--- a/src/components/cognicanvas/tools/game-center.tsx
+++ b/src/components/cognicanvas/tools/game-center.tsx
@@ -6,7 +6,10 @@ import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '@/componen
 import { Button } from '@/components/ui/button';
 import { AgentStream } from '@/components/cognicanvas/agent-stream';
 import { SmartSuggestions } from '@/components/cognicanvas/smart-suggestions';
-import { Gamepad2, Puzzle, Spade, ArrowLeft, LayoutGrid } from 'lucide-react';
+import { 
+  Gamepad2, Puzzle, Spade, ArrowLeft, LayoutGrid, RotateCcw, Lightbulb, PlusCircle, 
+  Heart, Club, Diamond, MinusCircle, CheckCircle, XCircle, CircleDollarSign
+} from 'lucide-react';
 import React, { useState } from 'react';
 
 interface Game {
@@ -74,25 +77,153 @@ export const GameCenter: React.FC<ToolProps> = ({ tool, onContentChange }) => {
 
   const renderSelectedGame = () => {
     if (!selectedGame) return null;
-    return (
-      <div className="flex flex-col items-center justify-center h-full p-4 text-center">
-        <Button 
-          variant="ghost" 
-          onClick={handleBackToSelection} 
-          className="absolute top-4 left-4 text-sm"
+
+    const commonLayoutClasses = "w-full h-full p-4 flex flex-col items-center justify-center bg-card text-card-foreground";
+    
+    const header = (
+      <div className="w-full relative text-center mb-4">
+        <Button
+          variant="ghost"
+          onClick={handleBackToSelection}
+          className="absolute top-0 left-0 text-sm text-muted-foreground hover:text-foreground"
         >
           <ArrowLeft className="mr-2 h-4 w-4" />
-          Back to Games
+          Back
         </Button>
-        <selectedGame.icon className="w-20 h-20 mb-6 text-primary" />
-        <h2 className="text-3xl font-semibold mb-3 text-foreground">{selectedGame.name}</h2>
+        <div className="flex flex-col items-center justify-center pt-2">
+          <selectedGame.icon className="w-10 h-10 mb-2 text-primary" />
+          <h2 className="text-2xl font-semibold">{selectedGame.name}</h2>
+        </div>
+      </div>
+    );
+
+    if (selectedGame.id === 'chess') {
+      const boardSize = 8;
+      const initialBoard = [
+        ['♜', '♞', '♝', '♛', '♚', '♝', '♞', '♜'],
+        ['♟', '♟', '♟', '♟', '♟', '♟', '♟', '♟'],
+        ['', '', '', '', '', '', '', ''],
+        ['', '', '', '', '', '', '', ''],
+        ['', '', '', '', '', '', '', ''],
+        ['', '', '', '', '', '', '', ''],
+        ['♙', '♙', '♙', '♙', '♙', '♙', '♙', '♙'],
+        ['♖', '♘', '♗', '♕', '♔', '♗', '♘', '♖'],
+      ];
+
+      return (
+        <div className={commonLayoutClasses}>
+          {header}
+          <div className="flex flex-col items-center">
+            <div className="grid grid-cols-8 w-[320px] h-[320px] md:w-[400px] md:h-[400px] border border-foreground shadow-xl">
+              {Array.from({ length: boardSize * boardSize }).map((_, i) => {
+                const row = Math.floor(i / boardSize);
+                const col = i % boardSize;
+                const isLightSquare = (row + col) % 2 === 0;
+                const piece = initialBoard[row]?.[col];
+                return (
+                  <div
+                    key={i}
+                    className={`flex items-center justify-center text-2xl md:text-3xl 
+                                ${isLightSquare ? 'bg-yellow-100' : 'bg-yellow-600'}
+                                ${piece && (row < 2) ? 'text-black' : 'text-white'}`}
+                  >
+                    {piece}
+                  </div>
+                );
+              })}
+            </div>
+            <div className="mt-4 flex space-x-2">
+              <Button variant="outline"><PlusCircle className="mr-2 h-4 w-4" /> New Game</Button>
+              <Button variant="outline"><Lightbulb className="mr-2 h-4 w-4" /> Hint</Button>
+              <Button variant="outline"><RotateCcw className="mr-2 h-4 w-4" /> Undo Move</Button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    if (selectedGame.id === 'poker') {
+      const CardPlaceholder = ({ suit, rank }: { suit?: React.ElementType, rank?: string }) => (
+        <div className="w-14 h-20 md:w-16 md:h-24 bg-white border border-gray-300 rounded-md flex flex-col items-center justify-center shadow-sm text-gray-700">
+          {suit && <suit className="h-6 w-6 md:h-8 md:w-8 mb-1" />}
+          {rank && <span className="text-lg md:text-xl font-bold">{rank}</span>}
+          {!suit && !rank && <div className="w-full h-full bg-gray-100 rounded-md" />}
+        </div>
+      );
+
+      return (
+        <div className={commonLayoutClasses}>
+          {header}
+          <div className="w-full max-w-2xl flex flex-col items-center bg-green-700 p-4 md:p-6 rounded-xl shadow-2xl border-4 border-green-800">
+            {/* Community Cards */}
+            <div className="mb-4 md:mb-6">
+              <h3 className="text-sm text-yellow-200 uppercase tracking-wider mb-2 text-center">Community Cards</h3>
+              <div className="flex space-x-2">
+                <CardPlaceholder suit={Spade} rank="A" />
+                <CardPlaceholder suit={Heart} rank="K" />
+                <CardPlaceholder suit={Club} rank="Q" />
+                <CardPlaceholder />
+                <CardPlaceholder />
+              </div>
+            </div>
+
+            {/* Player Areas */}
+            <div className="w-full flex justify-between items-end mb-4 md:mb-6">
+              {/* Opponent Hand */}
+              <div className="flex flex-col items-center">
+                <div className="flex space-x-1">
+                  <CardPlaceholder />
+                  <CardPlaceholder />
+                </div>
+                <span className="text-xs text-yellow-100 mt-1">AI Opponent</span>
+                <div className="mt-1 bg-red-600 text-white px-2 py-0.5 text-xs rounded-full shadow">Bet: $100</div>
+              </div>
+              {/* Pot */}
+              <div className="flex flex-col items-center">
+                  <CircleDollarSign className="h-8 w-8 text-yellow-400 mb-1"/>
+                  <span className="text-lg font-bold text-white bg-black/30 px-3 py-1 rounded">Pot: $250</span>
+              </div>
+              {/* Player Hand */}
+              <div className="flex flex-col items-center">
+                <div className="flex space-x-1">
+                  <CardPlaceholder suit={Diamond} rank="7" />
+                  <CardPlaceholder suit={Heart} rank="2" />
+                </div>
+                <span className="text-xs text-yellow-100 mt-1">Your Hand</span>
+                <div className="mt-1 bg-blue-600 text-white px-2 py-0.5 text-xs rounded-full shadow">Bet: $50</div>
+              </div>
+            </div>
+            
+            {/* Action Buttons */}
+            <div className="flex flex-wrap justify-center gap-2">
+              <Button variant="secondary" className="bg-blue-500 hover:bg-blue-600 text-white shadow-md">
+                <PlusCircle className="mr-2 h-4 w-4" /> Deal
+              </Button>
+              <Button variant="secondary" className="bg-yellow-500 hover:bg-yellow-600 text-black shadow-md">
+                <CircleDollarSign className="mr-2 h-4 w-4" /> Bet/Raise
+              </Button>
+              <Button variant="secondary" className="bg-gray-200 hover:bg-gray-300 text-black shadow-md">
+                <CheckCircle className="mr-2 h-4 w-4" /> Check
+              </Button>
+              <Button variant="secondary" className="bg-red-500 hover:bg-red-600 text-white shadow-md">
+                <XCircle className="mr-2 h-4 w-4" /> Fold
+              </Button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // Fallback
+    return (
+      <div className="flex flex-col items-center justify-center h-full p-4 text-center">
+        {header}
         <p className="text-muted-foreground mb-4">
-          The interface for {selectedGame.name} will be displayed here.
+          The interface for {selectedGame.name} is under construction.
         </p>
-        <div className="w-full max-w-md p-8 border border-dashed rounded-lg bg-background shadow-inner">
+        <div className="w-full max-w-md p-8 border border-dashed rounded-lg bg-card shadow-inner">
           <p className="text-sm text-muted-foreground">
-            Imagine a fully interactive {selectedGame.name.toLowerCase().split(' ')[0]} board here, with all the controls and AI feedback.
-            For now, you can interact with the AI agent on the right panel for tips or general queries about the game.
+            AI assistance for {selectedGame.name.toLowerCase()} is available via the agent panel.
           </p>
         </div>
       </div>

--- a/src/components/cognicanvas/tools/presentation-builder.tsx
+++ b/src/components/cognicanvas/tools/presentation-builder.tsx
@@ -3,11 +3,20 @@
 
 import type { ToolProps } from '@/components/cognicanvas/types';
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { AgentStream } from '@/components/cognicanvas/agent-stream';
 import { SmartSuggestions } from '@/components/cognicanvas/smart-suggestions';
-import { Presentation } from 'lucide-react';
+import { Presentation, PlusSquare, Type, Image as ImageIcon, Palette, Play, Sparkles } from 'lucide-react';
 
 export const PresentationBuilder: React.FC<ToolProps> = ({ tool, onContentChange }) => {
+  const slides = [
+    { id: 1, title: "Introduction", content: "Welcome to the presentation!" },
+    { id: 2, title: "Key Points", content: "Discussing main topics here." },
+    { id: 3, title: "Visuals", content: "Showing some charts and images." },
+    { id: 4, title: "Conclusion", content: "Summary and Q&A." },
+  ];
+  const [currentSlide, setCurrentSlide] = React.useState(slides[0]);
+
   return (
     <Card className="h-full flex flex-col shadow-xl rounded-lg overflow-hidden border-border bg-card">
       <CardHeader className="bg-card border-b p-4">
@@ -18,11 +27,46 @@ export const PresentationBuilder: React.FC<ToolProps> = ({ tool, onContentChange
       </CardHeader>
       <CardContent className="p-0 flex-grow flex flex-row overflow-hidden">
         {/* Main Tool content area */}
-        <div className="flex-grow flex flex-col items-center justify-center p-4 bg-card text-muted-foreground">
-          <Presentation className="w-16 h-16 mb-4 text-primary/30" />
-          <h2 className="text-xl font-semibold mb-2 text-foreground">{tool.name} UI</h2>
-          <p className="text-center">The main interface for {tool.name} will be implemented here.</p>
-          <p className="text-xs mt-2">(e.g., slide editor, themes, speaker notes)</p>
+        <div className="flex-grow flex flex-col bg-muted/30">
+          {/* Top Bar */}
+          <div className="bg-card border-b p-2 flex items-center space-x-1">
+            <Button variant="ghost" size="sm"><PlusSquare className="mr-2 h-4 w-4" /> New Slide</Button>
+            <Button variant="ghost" size="sm"><Type className="mr-2 h-4 w-4" /> Textbox</Button>
+            <Button variant="ghost" size="sm"><ImageIcon className="mr-2 h-4 w-4" /> Image</Button>
+            <Button variant="ghost" size="sm"><Palette className="mr-2 h-4 w-4" /> Themes</Button>
+            <div className="flex-grow" />
+            <Button variant="ghost" size="sm"><Sparkles className="mr-2 h-4 w-4 text-yellow-500" /> AI Assist</Button>
+            <Button size="sm" className="bg-primary hover:bg-primary/90">
+              <Play className="mr-2 h-4 w-4" /> Present
+            </Button>
+          </div>
+
+          {/* Main Content Area (Sidebar + Current Slide) */}
+          <div className="flex-grow flex flex-row overflow-hidden">
+            {/* Sidebar for Slide Thumbnails */}
+            <div className="w-48 bg-card border-r p-2 space-y-2 overflow-y-auto">
+              {slides.map((slide, index) => (
+                <div
+                  key={slide.id}
+                  onClick={() => setCurrentSlide(slide)}
+                  className={`p-2 border rounded-md cursor-pointer aspect-[16/9] flex flex-col justify-center items-center text-xs
+                              ${currentSlide.id === slide.id ? 'bg-primary/20 border-primary shadow-md' : 'bg-muted hover:bg-muted/80'}`}
+                >
+                  <span className="font-semibold text-muted-foreground mb-1">Slide {index + 1}</span>
+                  <p className="text-center text-muted-foreground/80 truncate w-full px-1">{slide.title}</p>
+                </div>
+              ))}
+            </div>
+
+            {/* Current Slide Area */}
+            <div className="flex-grow p-4 md:p-8 flex items-center justify-center">
+              <div className="w-full aspect-[16/9] bg-white shadow-xl rounded-lg p-6 md:p-10 flex flex-col items-center justify-center border">
+                <h2 className="text-xl md:text-3xl font-semibold text-gray-800 mb-4 text-center">{currentSlide.title}</h2>
+                <p className="text-sm md:text-base text-gray-600 text-center">{currentSlide.content}</p>
+                <div className="mt-auto text-xs text-gray-400">Slide {slides.findIndex(s => s.id === currentSlide.id) + 1} of {slides.length}</div>
+              </div>
+            </div>
+          </div>
         </div>
         {/* Agent Stream + Smart Suggestions part */}
         <div className="w-[340px] md:w-[380px] lg:w-[420px] border-l border-border flex flex-col bg-sidebar text-sidebar-foreground shrink-0">

--- a/src/components/cognicanvas/tools/settings-tool.tsx
+++ b/src/components/cognicanvas/tools/settings-tool.tsx
@@ -3,11 +3,120 @@
 
 import type { ToolProps } from '@/components/cognicanvas/types';
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Label } from '@/components/ui/label';
 import { AgentStream } from '@/components/cognicanvas/agent-stream';
 import { SmartSuggestions } from '@/components/cognicanvas/smart-suggestions';
-import { Settings } from 'lucide-react';
+import { Settings, Palette, User, Bell, Puzzle, Keyboard, Info } from 'lucide-react';
+import React, { useState } from 'react';
+
+type SettingsCategory = 'appearance' | 'account' | 'notifications' | 'integrations' | 'keyboard' | 'about';
+
+interface CategoryItem {
+  id: SettingsCategory;
+  name: string;
+  icon: React.ElementType;
+}
+
+const settingCategories: CategoryItem[] = [
+  { id: 'appearance', name: 'Appearance', icon: Palette },
+  { id: 'account', name: 'Account', icon: User },
+  { id: 'notifications', name: 'Notifications', icon: Bell },
+  { id: 'integrations', name: 'Integrations', icon: Puzzle },
+  { id: 'keyboard', name: 'Keyboard Shortcuts', icon: Keyboard },
+  { id: 'about', name: 'About', icon: Info },
+];
 
 export const SettingsTool: React.FC<ToolProps> = ({ tool, onContentChange }) => {
+  const [activeCategory, setActiveCategory] = useState<SettingsCategory>('appearance');
+
+  const renderCategoryContent = () => {
+    switch (activeCategory) {
+      case 'appearance':
+        return (
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-2">Theme</h3>
+              <Select defaultValue="system">
+                <SelectTrigger className="w-full md:w-1/2">
+                  <SelectValue placeholder="Select theme" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="light">Light</SelectItem>
+                  <SelectItem value="dark">Dark</SelectItem>
+                  <SelectItem value="system">System</SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground mt-1">Choose how CogniCanvas looks to you.</p>
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-2">Font Size</h3>
+              <RadioGroup defaultValue="medium" className="flex space-x-4">
+                <div>
+                  <RadioGroupItem value="small" id="font-small" />
+                  <Label htmlFor="font-small" className="ml-2 cursor-pointer">Small</Label>
+                </div>
+                <div>
+                  <RadioGroupItem value="medium" id="font-medium" />
+                  <Label htmlFor="font-medium" className="ml-2 cursor-pointer">Medium</Label>
+                </div>
+                <div>
+                  <RadioGroupItem value="large" id="font-large" />
+                  <Label htmlFor="font-large" className="ml-2 cursor-pointer">Large</Label>
+                </div>
+              </RadioGroup>
+               <p className="text-xs text-muted-foreground mt-1">Adjust the font size for better readability.</p>
+            </div>
+          </div>
+        );
+      case 'notifications':
+        return (
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-2">Email Notifications</h3>
+              <div className="flex items-center space-x-2">
+                <Switch id="email-notifications" defaultChecked />
+                <Label htmlFor="email-notifications" className="cursor-pointer">Enable Email Notifications</Label>
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">Receive updates and alerts via email.</p>
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-2">Push Notifications</h3>
+              <div className="flex items-center space-x-2">
+                <Switch id="push-notifications" />
+                <Label htmlFor="push-notifications" className="cursor-pointer">Enable Push Notifications</Label>
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">Get real-time alerts directly on your device.</p>
+            </div>
+             <div>
+              <h3 className="text-lg font-medium text-foreground mb-2">Notification Sound</h3>
+              <div className="flex items-center space-x-2">
+                <Switch id="sound-notifications" defaultChecked/>
+                <Label htmlFor="sound-notifications" className="cursor-pointer">Enable Sound</Label>
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">Play a sound for new notifications.</p>
+            </div>
+          </div>
+        );
+      default:
+        return (
+          <div className="flex flex-col items-center justify-center h-full text-center">
+            <settingCategories.find(cat => cat.id === activeCategory)?.icon 
+              className="w-16 h-16 mb-4 text-primary/30" />
+            <h2 className="text-xl font-semibold mb-2 text-foreground">
+              {settingCategories.find(cat => cat.id === activeCategory)?.name} Settings
+            </h2>
+            <p className="text-muted-foreground">
+              Settings for this category will be displayed here.
+            </p>
+          </div>
+        );
+    }
+  };
+
   return (
     <Card className="h-full flex flex-col shadow-xl rounded-lg overflow-hidden border-border bg-card">
       <CardHeader className="bg-card border-b p-4">
@@ -18,11 +127,26 @@ export const SettingsTool: React.FC<ToolProps> = ({ tool, onContentChange }) => 
       </CardHeader>
       <CardContent className="p-0 flex-grow flex flex-row overflow-hidden">
         {/* Main Tool content area */}
-        <div className="flex-grow flex flex-col items-center justify-center p-4 bg-card text-muted-foreground">
-          <Settings className="w-16 h-16 mb-4 text-primary/30" />
-          <h2 className="text-xl font-semibold mb-2 text-foreground">{tool.name} UI</h2>
-          <p className="text-center">The main interface for {tool.name} will be implemented here.</p>
-           <p className="text-xs mt-2">(e.g., appearance, account, integrations)</p>
+        <div className="flex-grow flex flex-row bg-background">
+          {/* Sidebar for Settings Categories */}
+          <div className="w-60 bg-card border-r p-3 space-y-1">
+            {settingCategories.map((category) => (
+              <Button
+                key={category.id}
+                variant={activeCategory === category.id ? "secondary" : "ghost"}
+                className="w-full justify-start text-sm"
+                onClick={() => setActiveCategory(category.id)}
+              >
+                <category.icon className="mr-2 h-4 w-4" />
+                {category.name}
+              </Button>
+            ))}
+          </div>
+
+          {/* Main Settings Area */}
+          <div className="flex-grow p-6 overflow-y-auto">
+            {renderCategoryContent()}
+          </div>
         </div>
         {/* Agent Stream + Smart Suggestions part */}
         <div className="w-[340px] md:w-[380px] lg:w-[420px] border-l border-border flex flex-col bg-sidebar text-sidebar-foreground shrink-0">

--- a/src/components/cognicanvas/tools/spreadsheet-tool.tsx
+++ b/src/components/cognicanvas/tools/spreadsheet-tool.tsx
@@ -3,11 +3,37 @@
 
 import type { ToolProps } from '@/components/cognicanvas/types';
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { AgentStream } from '@/components/cognicanvas/agent-stream';
 import { SmartSuggestions } from '@/components/cognicanvas/smart-suggestions';
-import { Table } from 'lucide-react';
+import { 
+  Table, Bold, Italic, Palette as FillColorIcon, Combine, ArrowDownAZ, Sigma, PlusSquare, Sparkles
+} from 'lucide-react';
+import React, { useState } from 'react';
+
+const NUM_ROWS = 20;
+const NUM_COLS = 10; // A-J
 
 export const SpreadsheetTool: React.FC<ToolProps> = ({ tool, onContentChange }) => {
+  const [selectedCell, setSelectedCell] = useState<string | null>('A1');
+  const [formula, setFormula] = useState<string>('');
+  const [sheets, setSheets] = useState(['Sheet1', 'Sheet2']);
+  const [activeSheet, setActiveSheet] = useState('Sheet1');
+
+  const dummyData: { [key: string]: string | number } = {
+    'A1': 'Name', 'B1': 'Sales', 'C1': 'Date',
+    'A2': 'Product A', 'B2': 1500, 'C2': '2024-07-01',
+    'A3': 'Product B', 'B3': 2200, 'C3': '2024-07-02',
+    'A4': 'Product C', 'B4': 800, 'C4': '2024-07-03',
+    'B5': '=SUM(B2:B4)',
+  };
+
+  const renderCellContent = (rowIndex: number, colIndex: number) => {
+    const cellId = `${String.fromCharCode(65 + colIndex)}${rowIndex + 1}`;
+    return dummyData[cellId] || '';
+  };
+
   return (
     <Card className="h-full flex flex-col shadow-xl rounded-lg overflow-hidden border-border bg-card">
       <CardHeader className="bg-card border-b p-4">
@@ -18,11 +44,100 @@ export const SpreadsheetTool: React.FC<ToolProps> = ({ tool, onContentChange }) 
       </CardHeader>
       <CardContent className="p-0 flex-grow flex flex-row overflow-hidden">
         {/* Main Tool content area */}
-        <div className="flex-grow flex flex-col items-center justify-center p-4 bg-card text-muted-foreground">
-          <Table className="w-16 h-16 mb-4 text-primary/30" />
-          <h2 className="text-xl font-semibold mb-2 text-foreground">{tool.name} UI</h2>
-          <p className="text-center">The main interface for {tool.name} will be implemented here.</p>
-           <p className="text-xs mt-2">(e.g., grid, formulas, charts)</p>
+        <div className="flex-grow flex flex-col bg-muted/30 text-sm">
+          {/* Toolbar */}
+          <div className="bg-card border-b p-1.5 flex items-center space-x-1 overflow-x-auto">
+            <Button variant="ghost" size="icon_sm"><Bold className="h-4 w-4" /></Button>
+            <Button variant="ghost" size="icon_sm"><Italic className="h-4 w-4" /></Button>
+            <Button variant="ghost" size="icon_sm"><FillColorIcon className="h-4 w-4" /></Button>
+            <Button variant="ghost" size="icon_sm"><Combine className="h-4 w-4" /></Button>
+            <Button variant="ghost" size="icon_sm"><ArrowDownAZ className="h-4 w-4" /></Button>
+            <div className="border-l h-5 mx-1"></div>
+            <Button variant="ghost" size="icon_sm"><Sigma className="h-4 w-4" /></Button>
+             <div className="flex-grow" />
+            <Button variant="ghost" size="sm"><Sparkles className="mr-2 h-4 w-4 text-yellow-500" /> AI Formula</Button>
+          </div>
+
+          {/* Formula Bar */}
+          <div className="bg-card border-b p-1.5 flex items-center">
+            <div className="px-2 py-0.5 border-r text-xs text-muted-foreground font-mono mr-2">{selectedCell || 'A1'}</div>
+            <span className="text-muted-foreground italic font-mono text-sm mr-1.5">fx</span>
+            <Input 
+              type="text" 
+              placeholder="Enter formula or value" 
+              className="h-7 text-xs flex-grow focus-visible:ring-transparent ring-offset-0 border-0 shadow-none p-1"
+              value={formula}
+              onChange={(e) => setFormula(e.target.value)}
+              onFocus={() => {
+                const cellValue = selectedCell ? (dummyData[selectedCell] || '') : '';
+                setFormula(String(cellValue));
+              }}
+            />
+          </div>
+
+          {/* Spreadsheet Grid */}
+          <div className="flex-grow overflow-auto p-2 bg-background shadow-inner">
+            <table className="table-fixed border-collapse border border-slate-300">
+              <thead>
+                <tr>
+                  <th className="sticky top-0 left-0 z-20 bg-slate-100 border border-slate-300 w-10 h-6 text-xs font-normal text-muted-foreground"></th>
+                  {Array.from({ length: NUM_COLS }).map((_, colIndex) => (
+                    <th 
+                      key={colIndex} 
+                      className="sticky top-0 bg-slate-100 border border-slate-300 min-w-[80px] h-6 text-xs font-normal text-muted-foreground"
+                    >
+                      {String.fromCharCode(65 + colIndex)}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {Array.from({ length: NUM_ROWS }).map((_, rowIndex) => (
+                  <tr key={rowIndex}>
+                    <td className="sticky left-0 bg-slate-100 border border-slate-300 w-10 h-6 text-center text-xs font-normal text-muted-foreground">
+                      {rowIndex + 1}
+                    </td>
+                    {Array.from({ length: NUM_COLS }).map((_, colIndex) => {
+                      const cellId = `${String.fromCharCode(65 + colIndex)}${rowIndex + 1}`;
+                      return (
+                        <td 
+                          key={colIndex} 
+                          className={`border border-slate-300 p-0.5 min-w-[80px] h-6 text-xs cursor-cell
+                                      ${selectedCell === cellId ? 'ring-2 ring-primary ring-inset z-10' : ''}
+                                      ${typeof dummyData[cellId] === 'number' ? 'text-right' : 'text-left'}
+                                      ${String(dummyData[cellId]).startsWith('=') ? 'italic text-blue-600' : ''}`}
+                          onClick={() => {
+                            setSelectedCell(cellId);
+                            setFormula(String(dummyData[cellId] || ''));
+                          }}
+                        >
+                          {renderCellContent(rowIndex, colIndex)}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Bottom Bar (Sheet Tabs) */}
+          <div className="bg-card border-t p-1.5 flex items-center space-x-1 text-xs">
+            {sheets.map(sheetName => (
+              <Button 
+                key={sheetName} 
+                variant={activeSheet === sheetName ? "secondary" : "ghost"} 
+                size="sm"
+                className={`h-7 px-3 ${activeSheet === sheetName ? 'font-semibold' : ''}`}
+                onClick={() => setActiveSheet(sheetName)}
+              >
+                {sheetName}
+              </Button>
+            ))}
+            <Button variant="ghost" size="icon_sm" onClick={() => setSheets([...sheets, `Sheet${sheets.length + 1}`])}>
+              <PlusSquare className="h-4 w-4" />
+            </Button>
+          </div>
         </div>
         {/* Agent Stream + Smart Suggestions part */}
         <div className="w-[340px] md:w-[380px] lg:w-[420px] border-l border-border flex flex-col bg-sidebar text-sidebar-foreground shrink-0">

--- a/src/components/cognicanvas/tools/task-manager.tsx
+++ b/src/components/cognicanvas/tools/task-manager.tsx
@@ -3,11 +3,68 @@
 
 import type { ToolProps } from '@/components/cognicanvas/types';
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Badge } from '@/components/ui/badge';
 import { AgentStream } from '@/components/cognicanvas/agent-stream';
 import { SmartSuggestions } from '@/components/cognicanvas/smart-suggestions';
-import { ListChecks } from 'lucide-react'; 
+import { ListChecks, PlusSquare, CalendarDays, Flag, Filter, ArrowDownUp, Sparkles } from 'lucide-react'; 
+import React, { useState } from 'react';
+
+interface Task {
+  id: string;
+  name: string;
+  completed: boolean;
+  dueDate?: string;
+  priority?: 'high' | 'medium' | 'low';
+}
+
+const initialTasks: Task[] = [
+  { id: '1', name: 'Draft Q3 report for marketing team', completed: false, dueDate: '2024-08-15', priority: 'high' },
+  { id: '2', name: 'Schedule a follow-up meeting with Client X', completed: true, dueDate: '2024-08-10' },
+  { id: '3', name: 'Brainstorm new feature ideas for Project Alpha', completed: false, priority: 'medium' },
+  { id: '4', name: 'Update design system documentation', completed: false, dueDate: '2024-08-20', priority: 'low' },
+  { id: '5', name: 'Review and approve expense reports', completed: true },
+];
+
 
 export const TaskManager: React.FC<ToolProps> = ({ tool, onContentChange }) => {
+  const [tasks, setTasks] = useState<Task[]>(initialTasks);
+  const [newTaskName, setNewTaskName] = useState('');
+  const [filter, setFilter] = useState<'all' | 'pending' | 'completed'>('all');
+
+  const handleAddTask = () => {
+    if (newTaskName.trim() === '') return;
+    const newTask: Task = {
+      id: String(Date.now()),
+      name: newTaskName.trim(),
+      completed: false,
+    };
+    setTasks([newTask, ...tasks]);
+    setNewTaskName('');
+  };
+
+  const toggleTaskCompletion = (taskId: string) => {
+    setTasks(
+      tasks.map((task) =>
+        task.id === taskId ? { ...task, completed: !task.completed } : task
+      )
+    );
+  };
+  
+  const filteredTasks = tasks.filter(task => {
+    if (filter === 'pending') return !task.completed;
+    if (filter === 'completed') return task.completed;
+    return true;
+  });
+
+  const PriorityFlag = ({ priority }: { priority?: 'high' | 'medium' | 'low' }) => {
+    if (!priority) return null;
+    const color = priority === 'high' ? 'text-red-500' : priority === 'medium' ? 'text-yellow-500' : 'text-green-500';
+    return <Flag className={`h-4 w-4 ${color}`} />;
+  };
+
   return (
     <Card className="h-full flex flex-col shadow-xl rounded-lg overflow-hidden border-border bg-card">
       <CardHeader className="bg-card border-b p-4">
@@ -18,11 +75,69 @@ export const TaskManager: React.FC<ToolProps> = ({ tool, onContentChange }) => {
       </CardHeader>
       <CardContent className="p-0 flex-grow flex flex-row overflow-hidden">
         {/* Main Tool content area */}
-        <div className="flex-grow flex flex-col items-center justify-center p-4 bg-card text-muted-foreground">
-          <ListChecks className="w-16 h-16 mb-4 text-primary/30" />
-          <h2 className="text-xl font-semibold mb-2 text-foreground">{tool.name} UI</h2>
-          <p className="text-center">The main interface for {tool.name} will be implemented here.</p>
-          <p className="text-xs mt-2">(e.g., task lists, boards, calendars)</p>
+        <div className="flex-grow flex flex-col bg-muted/30 p-4 space-y-4">
+          {/* Add Task Input */}
+          <div className="flex space-x-2">
+            <Input 
+              placeholder="Enter new task..." 
+              value={newTaskName}
+              onChange={(e) => setNewTaskName(e.target.value)}
+              onKeyPress={(e) => e.key === 'Enter' && handleAddTask()}
+              className="bg-card"
+            />
+            <Button onClick={handleAddTask} className="whitespace-nowrap">
+              <PlusSquare className="mr-2 h-4 w-4" /> Add Task
+            </Button>
+            <Button variant="ghost" size="icon" className="text-yellow-500 hover:text-yellow-600">
+              <Sparkles className="h-5 w-5" />
+            </Button>
+          </div>
+
+          {/* Filters and Sort */}
+          <div className="flex items-center justify-between space-x-2 text-sm">
+            <div className="flex items-center space-x-1">
+              <Button variant={filter === 'all' ? 'secondary' : 'ghost'} size="sm" onClick={() => setFilter('all')}>All</Button>
+              <Button variant={filter === 'pending' ? 'secondary' : 'ghost'} size="sm" onClick={() => setFilter('pending')}>Pending</Button>
+              <Button variant={filter === 'completed' ? 'secondary' : 'ghost'} size="sm" onClick={() => setFilter('completed')}>Completed</Button>
+            </div>
+            <Button variant="ghost" size="sm">
+              <ArrowDownUp className="mr-2 h-4 w-4" /> Sort
+            </Button>
+          </div>
+
+          {/* Task List */}
+          <div className="flex-grow overflow-y-auto space-y-2 pr-1">
+            {filteredTasks.map(task => (
+              <Card key={task.id} className="p-3 bg-card shadow-sm hover:shadow-md transition-shadow">
+                <div className="flex items-center space-x-3">
+                  <Checkbox 
+                    id={`task-${task.id}`} 
+                    checked={task.completed} 
+                    onCheckedChange={() => toggleTaskCompletion(task.id)}
+                  />
+                  <label 
+                    htmlFor={`task-${task.id}`}
+                    className={`flex-grow text-sm cursor-pointer ${task.completed ? 'line-through text-muted-foreground' : 'text-card-foreground'}`}
+                  >
+                    {task.name}
+                  </label>
+                  {task.dueDate && (
+                    <Badge variant="outline" className="text-xs whitespace-nowrap">
+                      <CalendarDays className="mr-1.5 h-3 w-3" />
+                      {task.dueDate}
+                    </Badge>
+                  )}
+                  <PriorityFlag priority={task.priority} />
+                </div>
+              </Card>
+            ))}
+             {filteredTasks.length === 0 && (
+              <div className="text-center text-muted-foreground py-8">
+                <ListChecks className="mx-auto h-12 w-12 text-gray-400 mb-2" />
+                <p>No tasks {filter !== 'all' ? `in "${filter}"` : ''} here!</p>
+              </div>
+            )}
+          </div>
         </div>
         {/* Agent Stream + Smart Suggestions part */}
         <div className="w-[340px] md:w-[380px] lg:w-[420px] border-l border-border flex flex-col bg-sidebar text-sidebar-foreground shrink-0">


### PR DESCRIPTION
I've replaced placeholder content in various UI tools with simple, demonstrative interfaces to showcase their intended core functionalities.

Key changes:
- Code Editor: I added a mock code display area and dummy action buttons.
- Comms Hub: I implemented basic UIs for Email, Social Hub, and Video Call features.
- Creative Suite: I implemented basic UIs for Image, Music, and Video creation features.
- Game Center: I added visual representations for Chess and Poker.
- Presentation Builder: I created a mock slide editor and sorter view.
- Settings Tool: I implemented a mock settings panel with categories and example controls.
- Spreadsheet Tool: I added a mock grid, formula bar, and toolbar.
- Task Manager: I implemented a basic task list view with input and filter options.

All new UIs use existing `lucide-react` icons and `@/components/ui` components where appropriate. I performed a review to ensure general UI consistency across the tools, with a minor styling adjustment to Comms Hub.